### PR TITLE
Depend on compileVariantUnitTestSources

### DIFF
--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
@@ -93,7 +93,7 @@ class PitestPlugin implements Plugin<Project> {
                 group = PITEST_TASK_GROUP
             }
             variantTask.reportDir = new File(variantTask.reportDir, variant.name)
-            variantTask.dependsOn "compile${variant.name.capitalize()}UnitTestJavaWithJavac"
+            variantTask.dependsOn "compile${variant.name.capitalize()}UnitTestSources"
             globalTask.dependsOn variantTask
         }
     }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
@@ -47,6 +47,15 @@ class PitestPluginTest extends Specification {
             thrown(GradleException)
     }
 
+    def "depend on the Android task that copies resources to the build directory (for robolectric, etc)"() {
+        when:
+            Project project = AndroidUtils.createSampleLibraryProject()
+            project.evaluate()
+        then:
+            assert project.tasks[AndroidUtils.PITEST_RELEASE_TASK_NAME].getDependsOn().find {it == 'compileReleaseUnitTestSources'}
+            assert project.tasks["${PitestPlugin.PITEST_TASK_NAME}Debug"].getDependsOn().find {it == 'compileDebugUnitTestSources'}
+    }
+
     void assertThatTasksAreInGroup(Project project, List<String> taskNames, String group) {
         taskNames.each { String taskName ->
             Task task = project.tasks[taskName]


### PR DESCRIPTION
The compileVariantUnitTestJavaWithJavac does not copy the
resources from the test sources to the build directory,
which makes Robolectric tests fail in case they depend on
the robolectric.properties file.