### PR TITLE
Remove dependency on CharMatcher due to issues with Guava 22

### DIFF
--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
@@ -23,7 +23,6 @@ import com.android.build.gradle.api.AndroidSourceSet
 import com.android.build.gradle.api.BaseVariant
 import com.android.build.gradle.internal.api.TestedVariant
 import com.android.builder.model.AndroidProject
-import com.google.common.base.CharMatcher
 import groovy.transform.PackageScope
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -205,8 +204,11 @@ class PitestPlugin implements Plugin<Project> {
         }
         File outDir = new File(project.rootProject.buildDir, AndroidProject.FD_GENERATED)
 
-        CharMatcher safeCharacters = CharMatcher.JAVA_LETTER_OR_DIGIT | CharMatcher.anyOf('-.')
-        String sdkName = safeCharacters.negate().replaceFrom(android.compileSdkVersion, '-' as char)
+        String sdkName = sanitizeSdkVersion(android.compileSdkVersion)
         return new File(outDir, "mockable-" + sdkName + fileExt)
+    }
+
+    static def sanitizeSdkVersion(def version) {
+        return version.replaceAll('[^\\p{Alnum}.-]', '-')
     }
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
@@ -74,6 +74,13 @@ class PitestPluginTest extends Specification {
             assert classpath.find { it.toString().endsWith('sourceFolderJavaResources/test/variant1/release')}
     }
 
+    def "strange sdk versions get properly sanitized"() {
+        when:
+            def version = PitestPlugin.sanitizeSdkVersion('strange version (0)')
+        then:
+            assert version == 'strange-version--0-'
+    }
+
     void assertThatTasksAreInGroup(Project project, List<String> taskNames, String group) {
         taskNames.each { String taskName ->
             Task task = project.tasks[taskName]


### PR DESCRIPTION
While upgrading from Guava 21 to Guava 22, something broke in
CharMatcher. This is a requirement to upgrade to the Android
Gradle plugin 3.0.0.

The stack trace reads as follows:
org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'java.util.function.Predicate$$Lambda$345/1043479128@55b1079' with class 'java.util.function.Predicate$$Lambda$345/1043479128' to class 'com.google.common.base.CharMatcher'
        at info.solidsoft.gradle.pitest.PitestPlugin.getMockableAndroidJarPath(PitestPlugin.groovy:208)
        at info.solidsoft.gradle.pitest.PitestPlugin$_apply_closure1.doCall(PitestPlugin.groovy:74)

As a workaround, the Pitest plugin no longer depend on CharMatcher,
and uses a regular expression instead.