### PR TITLE
Fix classpath string splitting on Windows

### DIFF
--- a/src/funcTest/groovy/pl/droidsonroids/gradle/pitest/functional/KotlinPitestPluginFunctionalSpec.groovy
+++ b/src/funcTest/groovy/pl/droidsonroids/gradle/pitest/functional/KotlinPitestPluginFunctionalSpec.groovy
@@ -70,7 +70,6 @@ class KotlinPitestPluginFunctionalSpec extends AbstractPitestFunctionalSpec {
     }
 
     void "should run mutation analysis with kotlin Android plugin"() {
-        Assume.assumeFalse("PatternSyntaxException: Unexpected internal error near index 1 on Windows", System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT).contains("win"))
         when:
             copyResources("testProjects/simpleKotlin", "")
         then:

--- a/src/funcTest/groovy/pl/droidsonroids/gradle/pitest/functional/PitestPluginGeneralFunctionalSpec.groovy
+++ b/src/funcTest/groovy/pl/droidsonroids/gradle/pitest/functional/PitestPluginGeneralFunctionalSpec.groovy
@@ -2,7 +2,6 @@ package pl.droidsonroids.gradle.pitest.functional
 
 import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
-import org.junit.Assume
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import pl.droidsonroids.gradle.pitest.PitestPlugin
@@ -182,7 +181,6 @@ class PitestPluginGeneralFunctionalSpec extends AbstractPitestFunctionalSpec {
 
     @Issue("https://github.com/koral--/gradle-pitest-plugin/issues/87")
     void "should write reports for each variant separately"() {
-        Assume.assumeFalse("PatternSyntaxException: Unexpected internal error near index 1 on Windows", System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT).contains("win"))
         given:
             copyResources("testProjects/simpleKotlin", "")
         and:

--- a/src/main/groovy/pl/droidsonroids/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/pl/droidsonroids/gradle/pitest/PitestPlugin.groovy
@@ -298,8 +298,9 @@ class PitestPlugin implements Plugin<Project> {
             detectInlinedCode.set(pitestExtension.detectInlinedCode)
             timestampedReports.set(pitestExtension.timestampedReports)
             additionalClasspath.setFrom({
+                String splitter = File.separator.replace("\\", "\\\\")
                 FileCollection filteredCombinedTaskClasspath = combinedTaskClasspath.filter { File file ->
-                    if (pitestExtension.excludeMockableAndroidJar.getOrElse(false) && file.name == 'android.jar' && file.absolutePath.split(File.separator).contains('platforms')) {
+                    if (pitestExtension.excludeMockableAndroidJar.getOrElse(false) && file.name == 'android.jar' && file.absolutePath.split(splitter).contains('platforms')) {
                         return false
                     } else {
                         return !pitestExtension.fileExtensionsToFilter.getOrElse([]).find { extension -> file.name.endsWith(".$extension") }

--- a/src/test/groovy/pl/droidsonroids/gradle/pitest/PitestPluginTest.groovy
+++ b/src/test/groovy/pl/droidsonroids/gradle/pitest/PitestPluginTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Assume
 import spock.lang.Issue
 import spock.lang.Specification
 
@@ -47,7 +46,6 @@ class PitestPluginTest extends Specification {
 
     @Issue("https://github.com/koral--/gradle-pitest-plugin/issues/116")
     void "excludes mockable Android JAR"() {
-        Assume.assumeFalse(System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT).contains("win"))
         when:
             Project project = AndroidUtils.createSampleLibraryProject()
             project.android {


### PR DESCRIPTION
Potential fix for https://github.com/koral--/gradle-pitest-plugin/issues/116#issuecomment-1867313049