### PR TITLE
Specify Java toolchain version explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,12 @@ plugins {
     id 'com.vanniktech.maven.publish' version '0.25.3'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 ext.pitestAggregatorVersion = "1.15.0"   //Must be equal to default PIT version in PitestPlugin
 
 repositories {


### PR DESCRIPTION
Fixes #140 

# The issue

This Gradle plugin is now compiled with JDK 21, requiring all consumers to have at least this version of JDK as well, where as many Android projects can and do still use JDK 17. There also doesn't seem to be any specific reason as to why the plugin requires JDK 21 and couldn't use JDK 17 instead.

# The fix 

Specify Java toolchain version to 17 explicitly (minimum version required by Android Gradle plugin 8.5)