### PR TITLE
Ensure full runtime classpath passed to pitest (robolectric support)

### DIFF
--- a/src/main/groovy/pl/droidsonroids/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/pl/droidsonroids/gradle/pitest/PitestPlugin.groovy
@@ -235,6 +235,11 @@ class PitestPlugin implements Plugin<Project> {
                 from(project.configurations["compile"])
                 from(project.configurations["testCompile"])
             } else if (ANDROID_GRADLE_PLUGIN_VERSION_NUMBER.major > 4 && project.findProperty("android.enableJetifier") != "true") {
+                Configuration runtimeConfig = project.configurations.getByName("${variant.name}RuntimeClasspath")
+                from(runtimeConfig.copyRecursive { dependency ->
+                    dependency.properties.dependencyProject == null && dependency.version != null
+                }.shouldResolveConsistentlyWith(runtimeConfig))
+
                 Configuration unittestRuntimeConfig = project.configurations.getByName("${variant.name}UnitTestRuntimeClasspath")
                 from(unittestRuntimeConfig.copyRecursive { dependency ->
                     dependency.properties.dependencyProject == null && dependency.version != null


### PR DESCRIPTION
Hi @koral--, thanks for creating this plugin. 

I've been looking at getting Robolectric to run with pitest.

There are various issues, some of which will be solved by a plugin who hope to publish as part of arcmutate, but a fundamental problem is that the classpath passed to pitest by the gradle plugin does not match the one used when running tests normally.

It seems that (at least for the sample projects I have been working with) the 

<variant>UnitTestRuntimeClasspath

Contains only additional explicitly defined classpath elements. It does not automatically include the normal variant runtime classpath.

This change explicitly adds the runtime classpath elements.

Running my fork with excludeMockableJar set to **false**, and with our prototype android plugin, I am able to successfully mutation test using robolectrics tests.

Presumably this classpath issue also affects other types of tests not using Robolectric.