### PR TITLE
Ignore flavored variants added by baseline profile plugin.

### DIFF
--- a/src/funcTest/groovy/pl/droidsonroids/gradle/pitest/functional/BaselineProfileFunctionalSpec.groovy
+++ b/src/funcTest/groovy/pl/droidsonroids/gradle/pitest/functional/BaselineProfileFunctionalSpec.groovy
@@ -66,6 +66,77 @@ class BaselineProfileFunctionalSpec extends AbstractPitestFunctionalSpec {
             result.wasExecuted(':test')
     }
 
+    void "setup and run simple build on pitest infrastructure with baseline plugin with product flavors"() {
+        Assume.assumeFalse("StreamCorruptedException: invalid type code: 03 on Windows", System.getProperty("os.name", "unknown").toLowerCase(Locale.ROOT).contains("win"))
+        given:
+            buildFile << """
+                apply plugin: 'com.android.application'
+                apply plugin: 'androidx.baselineprofile'
+                apply plugin: 'pl.droidsonroids.pitest'
+
+                buildscript {
+                    repositories {
+                        google()
+                        mavenCentral()
+                    }
+                    dependencies {
+                        classpath 'com.android.tools.build:gradle:8.5.1'
+                        classpath 'androidx.baselineprofile:androidx.baselineprofile.gradle.plugin:1.4.1'
+                    }
+                }
+
+                android {
+                    namespace 'pl.drodsonroids.pitest'
+                    compileSdkVersion 30
+                    defaultConfig {
+                        minSdkVersion 10
+                        targetSdkVersion 30
+                    }
+                    flavorDimensions += "version"
+                    productFlavors {
+                        create("demo") {
+                            dimension = "version"
+                            applicationIdSuffix = ".demo"
+                            versionNameSuffix = "-demo"
+                        }
+                        create("full") {
+                            dimension = "version"
+                            applicationIdSuffix = ".full"
+                            versionNameSuffix = "-full"
+                        }
+                    }
+                    lintOptions {
+                        //ignore missing lint database
+                        abortOnError false
+                    }
+                    //targetProjectPath ':app'
+                }
+
+                repositories {
+                    google()
+                    mavenCentral()
+                }
+                dependencies {
+                    testImplementation 'junit:junit:4.13.2'
+                }
+            """.stripIndent()
+        and:
+            writeManifestFile()
+        when:
+            writeHelloWorld('gradle.pitest.test.hello')
+        then:
+            fileExists('src/main/java/gradle/pitest/test/hello/HelloWorld.java')
+        when:
+            writeTest('src/test/java/', 'gradle.pitest.test.hello', false)
+        then:
+            fileExists('src/test/java/gradle/pitest/test/hello/HelloWorldTest.java')
+        when:
+            ExecutionResult result = runTasksSuccessfully('build')
+        then:
+            isFileFound(projectDir, 'HelloWorld.class')
+            result.wasExecuted(':test')
+    }
+
     private static boolean isFileFound(File directory, String fileName) {
         boolean found = false
         directory.traverse(type: FileType.FILES) { file ->

--- a/src/main/groovy/pl/droidsonroids/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/pl/droidsonroids/gradle/pitest/PitestPlugin.groovy
@@ -211,7 +211,7 @@ class PitestPlugin implements Plugin<Project> {
 
     @SuppressWarnings(["Instanceof", "UnnecessarySetter", "DuplicateNumberLiteral"])
     private void configureTaskDefault(PitestTask task, BaseVariant variant, File mockableAndroidJar) {
-        if (project.plugins.hasPlugin("androidx.baselineprofile") && (variant.name.startsWith("nonMinified") || variant.name.startsWith("benchmark"))) {
+        if (isBaselineProfileVariant(variant)) {
             return
         }
         FileCollection combinedTaskClasspath = project.files()
@@ -364,6 +364,12 @@ class PitestPlugin implements Plugin<Project> {
         }
     }
 
+    private boolean isBaselineProfileVariant(BaseVariant variant) {
+        String flavoredNonMinified = variant.flavorName ? "${variant.flavorName}NonMinified" : "nonMinified"
+        String flavoredBenchmark = variant.flavorName ? "${variant.flavorName}Benchmark" : "benchmark"
+        return (project.plugins.hasPlugin("androidx.baselineprofile") && (variant.name.startsWith(flavoredNonMinified) || variant.name.startsWith(flavoredBenchmark)))
+    }
+
     private Provider<FileCollection> getJavaCompileClasspathProvider(BaseVariant variant) {
         return project.provider {
             getJavaCompileTask(variant).classpath
@@ -439,7 +445,7 @@ class PitestPlugin implements Plugin<Project> {
         //Related commit: https://github.com/gradle/gradle/commit/61220ea4fdb30b5c7265dd41e7ac4d70896c957b
         final String testImplementationConfigurationName = "testImplementation"
 
-        project.configurations.named(testImplementationConfigurationName).configure {  testImplementation ->
+        project.configurations.named(testImplementationConfigurationName).configure { testImplementation ->
             testImplementation.withDependencies { directDependencies ->
                 if (!pitestExtension.addJUnitPlatformLauncher.isPresent() || !pitestExtension.addJUnitPlatformLauncher.get()) {
                     log.info("'addJUnitPlatformLauncher' feature explicitly disabled in configuration. " +


### PR DESCRIPTION
Fixes #160 for projects using product flavors.

on-behalf-of: @e-solutions-GmbH <info@esolutions.de>